### PR TITLE
Add API URL env config for frontend services

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,3 @@
+# URL da API do backend
+BACKEND_API_URL=http://localhost:3333
+

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -60,6 +60,14 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Configuração de Ambiente
+
+Crie um arquivo `.env` na pasta `frontend` seguindo o exemplo abaixo para definir a URL da API do backend:
+
+```env
+BACKEND_API_URL=http://localhost:3333
+```
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/b5917eb5-5eb6-4f23-8b1b-37c23ce2a0dc) and click on Share -> Publish.

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,0 +1,3 @@
+const API_URL = import.meta.env.BACKEND_API_URL || 'http://localhost:3333'
+export default API_URL
+

--- a/frontend/src/services/backend/auth/index.ts
+++ b/frontend/src/services/backend/auth/index.ts
@@ -1,8 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import axios from 'axios';
-import { LoginCredentials, AuthResponse, User } from '@/common/types';
-
-const API_URL = 'http://localhost:3333'; // Ajuste conforme sua URL da API
+import axios from 'axios'
+import { LoginCredentials, AuthResponse, User } from '@/common/types'
+import API_URL from '@/services/api'
 
 const authService = {
   async login(credentials: LoginCredentials): Promise<AuthResponse> {

--- a/frontend/src/services/backend/comments/index.ts
+++ b/frontend/src/services/backend/comments/index.ts
@@ -1,8 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import axios from 'axios'
 import { CreateCommentRequest, UpdateCommentRequest, Comment } from '@/common/types'
-
-const API_URL = 'http://localhost:3333'
+import API_URL from '@/services/api'
 
 const commentService = {
   async getComments(): Promise<Comment[]> {

--- a/frontend/src/services/backend/occupations/index.ts
+++ b/frontend/src/services/backend/occupations/index.ts
@@ -1,8 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import axios from 'axios'
 import { CreateOccupationRequest, UpdateOccupationRequest, Occupation, UserOccupation } from '@/common/types'
-
-const API_URL = 'http://localhost:3333'
+import API_URL from '@/services/api'
 
 const occupationService = {
   async getOccupations(): Promise<Occupation[]> {

--- a/frontend/src/services/backend/profile/index.ts
+++ b/frontend/src/services/backend/profile/index.ts
@@ -1,8 +1,7 @@
 import { useMutation } from '@tanstack/react-query'
 import axios from 'axios'
 import { UpdateUserRequest, User } from '@/common/types'
-
-const API_URL = 'http://localhost:3333'
+import API_URL from '@/services/api'
 
 export interface ChangePasswordRequest {
   current_password: string

--- a/frontend/src/services/backend/projects/index.ts
+++ b/frontend/src/services/backend/projects/index.ts
@@ -2,8 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import axios from 'axios'
 import { Project, CreateProjectRequest, UpdateProjectRequest } from '@/common/types'
 import { transformApiProjectToFrontend } from '@/utils/apiTransformers'
-
-const API_URL = 'http://localhost:3333'
+import API_URL from '@/services/api'
 
 const projectService = {
   async getProjects(): Promise<Project[]> {

--- a/frontend/src/services/backend/roles/index.ts
+++ b/frontend/src/services/backend/roles/index.ts
@@ -1,8 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import axios from 'axios'
 import { CreateRoleRequest, UpdateRoleRequest, Role } from '@/common/types'
-
-const API_URL = 'http://localhost:3333'
+import API_URL from '@/services/api'
 
 const roleService = {
   async getRoles(): Promise<Role[]> {

--- a/frontend/src/services/backend/tasks/index.ts
+++ b/frontend/src/services/backend/tasks/index.ts
@@ -2,8 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import axios from 'axios'
 import { Task, CreateTaskRequest, UpdateTaskRequest } from '@/common/types'
 import { transformApiTaskToFrontend } from '@/utils/apiTransformers'
-
-const API_URL = 'http://localhost:3333'
+import API_URL from '@/services/api'
 
 const taskService = {
   async getTasks(): Promise<Task[]> {

--- a/frontend/src/services/backend/users/index.ts
+++ b/frontend/src/services/backend/users/index.ts
@@ -1,8 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import axios from 'axios';
+import axios from 'axios'
 import { CreateUserRequest, UpdateUserRequest, User } from '@/common/types'
-
-const API_URL = 'http://localhost:3333';
+import API_URL from '@/services/api'
 
 const userService = {
   async getUsers(): Promise<User[]> {


### PR DESCRIPTION
## Summary
- centralize backend API URL in `@/services/api`
- update all service modules to use the env variable
- document the new env var in README
- add `.env.example` to frontend with `VITE_API_URL`
- rename env variable to `BACKEND_API_URL`

## Testing
- `npm --prefix frontend run lint` *(fails: Cannot find package '@eslint/js')*
- `npm --prefix frontend run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684af587c4dc832395ab93fc51f99ec5