### PR TITLE
Mostrar filtro de usuário somente para admins

### DIFF
--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -433,22 +433,24 @@ const Tasks = () => {
                   ))}
                 </SelectContent>
               </Select>
-              <Select // NOVO FILTRO DE USUÁRIO
-                value={selectedUserId?.toString() || 'all'}
-                onValueChange={handleUserChange}
-              >
-                <SelectTrigger className="w-full sm:w-[180px]">
-                  <SelectValue placeholder="Responsável" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">Todos os usuários</SelectItem>
-                  {allUsers.map((u) => (
-                    <SelectItem key={u.id} value={u.id.toString()}>
-                      {u.name || `Usuário ${u.id}`} {/* Fallback para nome de usuário */}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              {permissions.isAdmin && (
+                <Select // NOVO FILTRO DE USUÁRIO
+                  value={selectedUserId?.toString() || 'all'}
+                  onValueChange={handleUserChange}
+                >
+                  <SelectTrigger className="w-full sm:w-[180px]">
+                    <SelectValue placeholder="Responsável" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">Todos os usuários</SelectItem>
+                    {allUsers.map((u) => (
+                      <SelectItem key={u.id} value={u.id.toString()}>
+                        {u.name || `Usuário ${u.id}`} {/* Fallback para nome de usuário */}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
               <Select
                 value={viewMode}
                 onValueChange={handleViewModeChange}


### PR DESCRIPTION
## Summary
- renderizar o filtro de usuários na página de tarefas somente quando o usuário é administrador

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684af715a6f08323b5afcb281d467fed